### PR TITLE
cmake install / export targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(adaptnotch)
+project(adaptnotch VERSION 0.1)
 
 set(CMAKE_CXX_STANDARD 14)
 if(NOT CMAKE_BUILD_TYPE)
@@ -12,7 +12,10 @@ find_package(Eigen3 REQUIRED)
 message(STATUS "Eigen Version: " ${EIGEN3_VERSION_STRING})
 
 add_library(adaptnotch SHARED src/adaptnotch.cpp)
-target_include_directories(adaptnotch PUBLIC include ${EIGEN3_INCLUDE_DIRS})
+target_include_directories(adaptnotch PUBLIC
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  ${EIGEN3_INCLUDE_DIRS})
 
 option(BUILD_EXAPPS "Build adaptnotch example" ON)
 
@@ -32,3 +35,33 @@ if(BUILD_EXAPPS)
   target_include_directories(main PUBLIC ${EIGEN3_INCLUDE_DIRS})
   target_link_libraries(main adaptnotch pthread plot)
 endif()
+
+
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/adaptnotch)
+
+install(TARGETS adaptnotch
+    EXPORT adaptnotch-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(EXPORT adaptnotch-targets
+  FILE adaptnotch-targets.cmake
+  DESTINATION ${INSTALL_CONFIGDIR})
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/adaptnotch-config-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(${CMAKE_CURRENT_LIST_DIR}/cmake/adaptnotch-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/adaptnotch-config.cmake
+  INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/adaptnotch-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/adaptnotch-config-version.cmake
+  DESTINATION ${INSTALL_CONFIGDIR})

--- a/cmake/adaptnotch-config.cmake.in
+++ b/cmake/adaptnotch-config.cmake.in
@@ -1,0 +1,14 @@
+# - Config file for the adaptnotch package
+# It defines the following variables
+#  ADAPTNOTCH_LIBRARIES    - libraries to link against
+
+# Compute paths
+get_filename_component(ADAPTNOTCH_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# Our library dependencies (contains definitions for IMPORTED targets)
+if(NOT TARGET foo)
+  include("${ADAPTNOTCH_CMAKE_DIR}/adaptnotch-targets.cmake")
+endif()
+
+# These are IMPORTED targets created by adaptnotch-targets.cmake
+set(ADAPTNOTCH_LIBRARIES adaptnotch)


### PR DESCRIPTION
Attempt to make superbuild pattern work with catkin builds


Following https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/ with code [here](https://github.com/pabloariasal/modern-cmake-sample/blob/master/libjsonutils/CMakeLists.txt)


---
This seems to really have been an issue for snapdragon pro compilation: in particular, w/o these changes, my desktop catkin was able to correctly link to the `build` space, but once pushed to sfpro, `snap` couldn't find `libadaptnotch.so`